### PR TITLE
update About page copy to reflect current TRX scope

### DIFF
--- a/trx_website/templates/About.jinja
+++ b/trx_website/templates/About.jinja
@@ -38,14 +38,14 @@
       Later titles – especially <em>The Last Revelation</em> – have long been
       well served by engines and tools like TRLE, TRNG, FLEP, and TE/TEN. But
       the first three games, the very bedrock of the series, were left trailing
-      behind. With TR1X and TR2X we've begun to change that, giving these
-      classics the attention and polish they've always deserved.
+      behind.
     </p>
     <p>
-      And one day, when we turn our focus to Tomb Raider III and its <em>Lost
-      Artifact</em> expansion, the circle will close: three legendary journeys
-      standing side by side, fully restored, enhanced, and shining as brightly
-      as the memories that keep them alive.
+      <em>TRX</em> changes that, giving these classics the attention and polish 
+      they've always deserved. Our open source reimplementation of the original
+      games gives you three legendary journeys side by side, including <em>Tomb 
+      Raider III: The Lost Artifact</em>, fully restored, enhanced, and shining 
+      as brightly as the memories that keep them alive.
     </p>
 
     <Heading level={{ 2 }}>Social media</Heading>


### PR DESCRIPTION
Consolidate the two-paragraph teaser into a single unified paragraph that presents TRX as covering all three games (including TR3 and Lost Artifact) rather than framing TR3 support as a future goal.